### PR TITLE
修复下载时的一些错误

### DIFF
--- a/Util/Download.py
+++ b/Util/Download.py
@@ -67,12 +67,13 @@ class Download():
                         # 23/02/09 更新xg参数
                         jx_url = Util.Urls().POST_DETAIL + Util.XBogus(
                             f'aweme_id={self.aweme_id[i]}&aid=1128&version_name=23.5.0&device_platform=android&os_version=2333').params
-                        js = Util.json.loads(Util.requests.get(
-                            url=jx_url, headers=self.headers).text)
+                        js = Util.requests.get(
+                            url=jx_url, headers=self.headers).text
                         # 防止接口多次返回空
                         while js == '':
-                            js = Util.json.loads(Util.requests.get(
-                                url=jx_url, headers=self.headers).text)
+                            js = Util.requests.get(
+                                url=jx_url, headers=self.headers).text
+                        js = Util.json.loads(js)
                         creat_time = Util.time.strftime(
                             "%Y-%m-%d %H.%M.%S", Util.time.localtime(js['aweme_detail']['create_time']))
                     except Exception as videoNotFound:
@@ -81,7 +82,7 @@ class Download():
                                 self.aweme_id[i])
                         Util.log.warning(
                             f'[  🚩🚩  ]: {self.nickname} 的视频 {self.aweme_id[i]} 下载失败')
-                        pass
+                        continue
 
                     # Code From RobotJohns https://github.com/RobotJohns
                     # 移除文件名称  /r/n


### PR DESCRIPTION
js = Util.requests.get(url=jx_url, headers=self.headers).text 应该从Util.json.loads()中抽离出来,否则返回数据为空时Util.json.loads()解析直接出错,走到except逻辑中,而不是继续下面的while js == ''继续请求的逻辑.

except捕获到异常后,应该continue继续下一个视频的下载,pass的话会继续向下执行,比如creat_time没有得到赋值就会直接报错.